### PR TITLE
feat: allow TOPIC_ID override from .env

### DIFF
--- a/init.config
+++ b/init.config
@@ -16,7 +16,19 @@ fi
 # Ensure the worker-data directory exists
 mkdir -p ./worker-data
 
-json_content=$(cat ./config.json)
+# Optionally load .env to pick up TOPIC_ID override
+if [ -f ./.env ]; then
+    # shellcheck disable=SC1091
+    set -a; . ./.env; set +a
+fi
+
+# Read config and optionally override topicId with $TOPIC_ID for all workers
+if [ -n "$TOPIC_ID" ]; then
+    echo "Overriding topicId to $TOPIC_ID from .env"
+    json_content=$(jq --argjson tid "$TOPIC_ID" '.worker |= map(.topicId = $tid)' ./config.json)
+else
+    json_content=$(cat ./config.json)
+fi
 stringified_json=$(echo "$json_content" | jq -c .)
 
 mnemonic=$(jq -r '.wallet.addressRestoreMnemonic' config.json)


### PR DESCRIPTION
This change makes `init.config` read `.env` and, if `TOPIC_ID` is defined, override all `worker[].topicId` entries before generating the worker env. This lets you set `TOPIC_ID=62` without editing JSON.