### PR TITLE
refactor: split ML config (mlconfig.json) from worker config.json

### DIFF
--- a/init.config
+++ b/init.config
@@ -16,7 +16,19 @@ fi
 # Ensure the worker-data directory exists
 mkdir -p ./worker-data
 
-json_content=$(cat ./config.json)
+# Optionally load .env to pick up TOPIC_ID override
+if [ -f ./.env ]; then
+    # shellcheck disable=SC1091
+    set -a; . ./.env; set +a
+fi
+
+# Read config and optionally override topicId with $TOPIC_ID for all workers
+if [ -n "$TOPIC_ID" ]; then
+    echo "Overriding topicId to $TOPIC_ID from .env"
+    json_content=$(jq --argjson tid "$TOPIC_ID" '.worker |= map(.topicId = $tid)' ./config.json)
+else
+    json_content=$(cat ./config.json)
+fi
 stringified_json=$(echo "$json_content" | jq -c .)
 
 mnemonic=$(jq -r '.wallet.addressRestoreMnemonic' config.json)

--- a/model_selection.py
+++ b/model_selection.py
@@ -8,7 +8,7 @@ from sklearn.svm import SVR
 from sklearn.kernel_ridge import KernelRidge
 from scipy.stats import zscore
 
-CONFIG_PATH = os.path.join(os.getcwd(), "config.json")
+CONFIG_PATH = os.path.join(os.getcwd(), "mlconfig.json")
 
 
 def zptae_loss(y_true: np.ndarray, y_pred: np.ndarray) -> float:


### PR DESCRIPTION
- Model selection now reads `mlconfig.json` to avoid interfering with your worker's `config.json`\n- You can freely edit `config.json` for Allora worker settings\n- CI, optimizer, and training keep using `mlconfig.json`